### PR TITLE
Allow user to provide a virtual file system

### DIFF
--- a/ftpd.js
+++ b/ftpd.js
@@ -36,7 +36,10 @@ function fixPath(fs, path) {
 }
 
 // host should be an IP address, and sandbox a path without trailing slash for now
-function createServer(host, sandbox) {
+function createServer(host, sandbox, virtualFS) {
+    if(virtualFS){
+    	fs = virtualFS;
+    }
     // make sure host is an IP address, otherwise DATA connections will likely break
     var server = net.createServer();
     server.baseSandbox = sandbox; // path which we're starting relative to


### PR DESCRIPTION
This would allow any module implimenting:

fs.unlink(path, callback(err))

fs.readdir(path, callback(err, files)

fs.statSync(path)
fs.stat(path, callback(err, s))

fs.mkdir(path, mode = 0755, callback(err))

fs.open(path, flags = 'r', callback(err, fd))
fs.read(fd, 4096, socket.totsize, socket.mode, callback(err, chunk, bytes_read))
fs.close(fd, callback)

fs.open(path, flags = 'w', 0644, callback(err, fd)
fs.write(fd, buf, 0, buf.length, null, writeCallback)

fs.rmdir(path, callback(err))

fs.rename(path, path, callback(err))

to be passed in, regardless of the actual store used on the back end (e.g. AmazonS3, Azure, etc.)

todo: convert to use stat rather than statSync as many virtual file systems may not support syncronous stat operation.
todo: provide user object to store so store can fail based on authorization?
todo: build sample virtual file system implimentation for at least one db type
