### PR TITLE
Fixes and updates for Windows

### DIFF
--- a/dummyfs.js
+++ b/dummyfs.js
@@ -7,7 +7,8 @@ function dummyfs(root) {
 exports.dummyfs = dummyfs;
 
 dummyfs.prototype.chdir = function(dir) {
-	this.dir = path.resolve(this.dir, dir);
+	// Updated from path.resolve to path.join, this fixes windows usage
+  this.dir = path.join(this.dir, dir);
 	return(this.dir);
 }
 


### PR DESCRIPTION
Updated to use path.join instead of path.resolve as on Windows
path.resolve will add in the drive letter (C:\temp isntead of
c:[ftpdir]\temp).  Enforced user directory creation, added
userdirectory to success() callback, and quit hit update for X commands
as used by Windows FTP.
