### PR TITLE
Fixed a bug when RETR command was send

### DIFF
--- a/ftpd.js
+++ b/ftpd.js
@@ -561,7 +561,7 @@ function createServer(host, sandbox) {
                 whenDataWritable( function(pasvconn) {
                     pasvconn.setEncoding(socket.mode);
 
-                    var filename = PathModule.resolve('/', commandArg);
+                    var filename = PathModule.resolve(socket.fs.cwd(), commandArg);
                     if(filename != socket.filename)
                     {
                         socket.totsize = 0;


### PR DESCRIPTION
Fixed a bug in the RETR command. If the working directory wasn't the root (sandbox) directory, the RETR command could fail or send a wrong file.
